### PR TITLE
Add missing separator insets

### DIFF
--- a/ahome-titanium/src/main/java/com/ait/toolkit/titanium/mobile/client/ui/ListView.java
+++ b/ahome-titanium/src/main/java/com/ait/toolkit/titanium/mobile/client/ui/ListView.java
@@ -24,6 +24,7 @@ import com.ait.toolkit.core.client.JsObject;
 import com.ait.toolkit.titanium.mobile.client.core.handlers.CallbackRegistration;
 import com.ait.toolkit.titanium.mobile.client.core.handlers.ui.ListViewItemClickHandler;
 import com.ait.toolkit.titanium.mobile.client.ui.fx.TableViewAnimation;
+import com.ait.toolkit.titanium.mobile.client.ui.iphone.ListViewSeparatorInsets;
 import com.google.gwt.core.client.JavaScriptObject;
 
 public class ListView extends View {
@@ -212,6 +213,28 @@ public class ListView extends View {
     public void setSeparatorColor( Color color ) {
         setSeparatorColor( color.getValue() );
     }
+
+    /**
+     * The insets for list view separators (applies to all cells). This property is applicable on iOS 7 and greater.
+     *
+     * In iOS 7 and later, cell separators do not extend all the way to the edge of the list view.
+     * This property sets the default inset for all cells in the table.
+     */
+    public native void setSeparatorInsets( ListViewSeparatorInsets insets) /*-{
+		var jso = this.@com.ait.toolkit.core.client.JsObject::getJsObj()();
+		jso.separatorInsets = insets.@com.ait.toolkit.titanium.mobile.client.ui.iphone.ListViewSeparatorInsets::getJsObj()();
+    }-*/;
+
+    /**
+     * The insets for list view separators (applies to all cells). This property is applicable on iOS 7 and greater.
+     *
+     * In iOS 7 and later, cell separators do not extend all the way to the edge of the list view.
+     * This property sets the default inset for all cells in the table.
+     */
+    public native ListViewSeparatorInsets getSeparatorInsets() /*-{
+		var jso = this.@com.ait.toolkit.core.client.JsObject::getJsObj()();
+		return @com.ait.toolkit.titanium.mobile.client.ui.iphone.ListViewSeparatorInsets::new(Lcom/google/gwt/core/client/JavaScriptObject;)(jso);
+    }-*/;
 
     /**
      * Separator style constant.

--- a/ahome-titanium/src/main/java/com/ait/toolkit/titanium/mobile/client/ui/iphone/ListViewSeparatorInsets.java
+++ b/ahome-titanium/src/main/java/com/ait/toolkit/titanium/mobile/client/ui/iphone/ListViewSeparatorInsets.java
@@ -1,0 +1,42 @@
+package com.ait.toolkit.titanium.mobile.client.ui.iphone;
+
+import com.ait.toolkit.core.client.JsObject;
+import com.ait.toolkit.core.client.JsoHelper;
+import com.google.gwt.core.client.JavaScriptObject;
+
+public class ListViewSeparatorInsets extends JsObject {
+
+    public ListViewSeparatorInsets() {
+        jsObj = JsoHelper.createObject();
+    }
+
+    protected ListViewSeparatorInsets( JavaScriptObject obj ) {
+        jsObj = obj;
+    }
+
+    public ListViewSeparatorInsets( String left, String right) {
+        this();
+        setLeft(left);
+        setRight(right);
+    }
+
+    public native String getLeft() /*-{
+		var jso = this.@com.ait.toolkit.core.client.JsObject::getJsObj()();
+		return jso.left;
+    }-*/;
+
+    public native void setLeft( String left ) /*-{
+		var jso = this.@com.ait.toolkit.core.client.JsObject::getJsObj()();
+		jso.left = left;
+    }-*/;
+
+    public native String getRight() /*-{
+		var jso = this.@com.ait.toolkit.core.client.JsObject::getJsObj()();
+		return jso.right;
+    }-*/;
+
+    public native void setRight( String right ) /*-{
+		var jso = this.@com.ait.toolkit.core.client.JsObject::getJsObj()();
+		jso.right = right;
+    }-*/;
+}


### PR DESCRIPTION
I've added the missing separator insets for ListView.

I've gone with the approach of adding a custom ListViewSeparatorInsets class even though the original Titanium method takes a dictionary, as this feels more suitable to Java. If you are not happy with this approach it can be changed.
